### PR TITLE
Add multi-arch Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# cs-firewall-bouncer
+# CrowdSec Firewall Bouncer Docker Image
+
+This repository provides a Dockerfile to build a minimal container for running the [CrowdSec firewall bouncer](https://github.com/crowdsecurity/cs-firewall-bouncer). The bouncer updates the host's iptables rules according to decisions from a CrowdSec Local API (LAPI).
+
+## Build
+
+```bash
+docker build -f docker/Dockerfile -t crowdsec-firewall-bouncer .
+```
+
+This Dockerfile supports multi-architecture builds (e.g. `amd64`, `arm64`, `armv7`)
+when used with Docker Buildx.
+
+## Usage
+
+The container expects at least the following environment variables:
+
+- `CROWDSEC_API_KEY` – API key used by the bouncer
+- `CROWDSEC_PORT` – port where the CrowdSec LAPI is reachable (default: `8080`)
+
+Optionally `CROWDSEC_LAPI_URL` can specify the full URL to the LAPI.
+
+Configuration lives in `/etc/crowdsec`. If `crowdsec-firewall-bouncer.yaml` is missing, the entrypoint copies a default file on first start. To persist changes, mount the directory as a volume:
+
+```bash
+docker run -d \
+  --name cs-firewall-bouncer \
+  --cap-add=NET_ADMIN --cap-add=NET_RAW \
+  -e CROWDSEC_API_KEY=<API_KEY> \
+  -e CROWDSEC_PORT=8080 \
+  -v /path/to/config:/etc/crowdsec \
+  --network=host \
+  crowdsec-firewall-bouncer
+```
+
+The image exposes no ports and is based on a minimal Alpine system.
+
+## Notes
+
+- Modifying firewall rules requires elevated privileges (`--cap-add=NET_ADMIN --cap-add=NET_RAW` or `--privileged`).
+- Ensure the CrowdSec LAPI is already running and reachable.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM alpine:latest AS builder
+
+ARG CS_VERSION=v0.0.33
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN apk add --no-cache curl ca-certificates tar
+
+WORKDIR /tmp/bouncer
+RUN ARCH="${TARGETARCH}${TARGETVARIANT}" \
+    && curl -L -o bouncer.tgz https://github.com/crowdsecurity/cs-firewall-bouncer/releases/download/${CS_VERSION}/crowdsec-firewall-bouncer-linux-${ARCH}.tgz \
+    && tar -xzf bouncer.tgz \
+    && mv crowdsec-firewall-bouncer*/crowdsec-firewall-bouncer /crowdsec-firewall-bouncer \
+    && mv crowdsec-firewall-bouncer*/config/crowdsec-firewall-bouncer.yaml /crowdsec-firewall-bouncer.yaml
+
+FROM alpine:latest
+
+ENV CROWDSEC_API_KEY="" \
+    CROWDSEC_PORT="8080" \
+    CROWDSEC_LAPI_URL=""
+
+RUN apk add --no-cache iptables gettext ca-certificates
+
+COPY --from=builder /crowdsec-firewall-bouncer /usr/local/bin/crowdsec-firewall-bouncer
+COPY --from=builder /crowdsec-firewall-bouncer.yaml /defaults/crowdsec-firewall-bouncer.yaml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+VOLUME ["/etc/crowdsec"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+CONFIG_DIR=/etc/crowdsec
+CONFIG_FILE="$CONFIG_DIR/crowdsec-firewall-bouncer.yaml"
+DEFAULT_CONFIG=/defaults/crowdsec-firewall-bouncer.yaml
+
+mkdir -p "$CONFIG_DIR"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    BACKEND=${BACKEND:-iptables}
+    API_KEY=${CROWDSEC_API_KEY:-}
+    BACKEND="$BACKEND" API_KEY="$API_KEY" envsubst < "$DEFAULT_CONFIG" > "$CONFIG_FILE"
+fi
+
+API_URL=${CROWDSEC_LAPI_URL:-http://host.docker.internal:${CROWDSEC_PORT:-8080}}
+# Ensure trailing slash
+case $API_URL in
+    */) ;;
+    *) API_URL="$API_URL/" ;;
+esac
+
+sed -i "s#^api_url:.*#api_url: ${API_URL}#" "$CONFIG_FILE"
+if [ -n "$CROWDSEC_API_KEY" ]; then
+    sed -i "s#^api_key:.*#api_key: ${CROWDSEC_API_KEY}#" "$CONFIG_FILE"
+fi
+
+exec crowdsec-firewall-bouncer -c "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- move Dockerfile to docker/ for workflow compatibility
- use TARGETARCH/TARGETVARIANT for release tarball
- document Dockerfile path and multi-arch build support in README

## Testing
- `sh -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68542669fc28832d89553119469b0c14