### PR TITLE
Add latest tag support

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -37,7 +37,7 @@ jobs:
           images: |
             ${{ env.GHCR_REPO }}
           flavor: |
-            suffix=-dev
+            suffix=-dev,onlatest=false
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -109,12 +109,13 @@ jobs:
           images: |
             ${{ env.GHCR_REPO }}
           flavor: |
-            suffix=-dev
+            suffix=-dev,onlatest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -105,12 +105,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.GHCR_REPO }}            
+            ${{ env.GHCR_REPO }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}            
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
## Summary
- ensure `latest` tag is published without changing workflow triggers
- keep dev workflow's suffix setting while disabling automatic `latest-dev`

## Testing
- `shellcheck entrypoint.sh`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545d709b48832dbe95ef527e450880