### PR TITLE
Add Prometheus configuration options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN case "$TARGETPLATFORM" in \
 FROM alpine:latest
 
 ENV CROWDSEC_PORT="8080" \
-    CROWDSEC_LAPI_URL=""
+    CROWDSEC_LAPI_URL="" \
+    PROMETHEUS_ENABLED="false" \
+    PROMETHEUS_PORT="60601"
 
 RUN apk update \
     && apk upgrade \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The container expects at least the following environment variables:
 
 - `CROWDSEC_API_KEY` – API key used by the bouncer
 - `CROWDSEC_PORT` – port where the CrowdSec LAPI is reachable (default: `8080`)
+- `PROMETHEUS_ENABLED` – set to `true` to enable the Prometheus endpoint (default: `false`)
+- `PROMETHEUS_PORT` – port for the Prometheus metrics endpoint (default: `60601`)
 
 Optionally `CROWDSEC_LAPI_URL` can specify the full URL to the LAPI.
 
@@ -26,6 +28,8 @@ docker run -d \
   -e CROWDSEC_API_KEY=<API_KEY> \
   -e CROWDSEC_PORT=8080 \
   -e CROWDSEC_LAPI_URL=http://127.0.0.1:8080 \
+  -e PROMETHEUS_ENABLED=false \
+  -e PROMETHEUS_PORT=60601 \
   -v /path/to/config:/etc/crowdsec \
   --network=host \
   crowdsec-firewall-bouncer

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,4 +25,10 @@ if [ -n "$CROWDSEC_API_KEY" ]; then
     sed -i "s#^api_key:.*#api_key: ${CROWDSEC_API_KEY}#" "$CONFIG_FILE"
 fi
 
+# Configure Prometheus metrics if requested
+PROMETHEUS_ENABLED=${PROMETHEUS_ENABLED:-false}
+PROMETHEUS_PORT=${PROMETHEUS_PORT:-60601}
+sed -i "0,/enabled:/s/enabled:.*/enabled: ${PROMETHEUS_ENABLED}/" "$CONFIG_FILE"
+sed -i "0,/listen_port:/s/listen_port:.*/listen_port: ${PROMETHEUS_PORT}/" "$CONFIG_FILE"
+
 exec crowdsec-firewall-bouncer -c "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- document Prometheus env vars in README
- set default Prometheus env vars in Dockerfile
- configure Prometheus in entrypoint based on env vars

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6854860afb04832da8ec2328fd92377f