### PR TITLE
Add automatic update workflow

### DIFF
--- a/.github/workflows/update-bouncer.yml
+++ b/.github/workflows/update-bouncer.yml
@@ -1,0 +1,36 @@
+name: Update crowdsec firewall bouncer
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Get current version
+        id: current
+        run: echo "version=$(grep -oP '(?<=ARG CS_VERSION=).*' Dockerfile)" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest release
+        id: latest
+        run: |
+          latest=$(curl -s https://api.github.com/repos/crowdsecurity/cs-firewall-bouncer/releases/latest | jq -r '.tag_name')
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Update version
+        if: steps.current.outputs.version != steps.latest.outputs.version
+        run: |
+          sed -i "s/ARG CS_VERSION=.*/ARG CS_VERSION=${{ steps.latest.outputs.version }}/" Dockerfile
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "chore: update bouncer to ${{ steps.latest.outputs.version }}"
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM alpine:latest AS builder
 
+# This version is automatically updated by the workflow
 ARG CS_VERSION=v0.0.33
 
 ARG TARGETPLATFORM
 
-RUN apk add --no-cache curl ca-certificates tar
+RUN apk add --no-cache curl ca-certificates tar jq
 
 WORKDIR /tmp/bouncer
-RUN case "$TARGETPLATFORM" in \
+RUN if [ "$CS_VERSION" = "latest" ]; then \
+        CS_VERSION=$(curl -s https://api.github.com/repos/crowdsecurity/cs-firewall-bouncer/releases/latest | jq -r '.tag_name'); \
+    fi \
+    && case "$TARGETPLATFORM" in \
         "linux/amd64") CS_ARCH=amd64 ;; \
         "linux/arm64") CS_ARCH=arm64 ;; \
         "linux/arm/v7") CS_ARCH=armv7 ;; \


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that checks every four hours for new releases of crowdsecurity/cs-firewall-bouncer and updates `Dockerfile` if needed
- allow building the Docker image with `CS_VERSION=latest`

## Testing
- `shellcheck entrypoint.sh` *(fails: command not found)*
- `yamllint .github/workflows/update-bouncer.yml` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68548c057ef0832d887df81759f78240