### PR TITLE
Add tag step in bouncer update workflow

### DIFF
--- a/.github/workflows/update-bouncer.yml
+++ b/.github/workflows/update-bouncer.yml
@@ -34,3 +34,5 @@ jobs:
           git config user.email "github-actions@github.com"
           git commit -am "chore: update bouncer to ${{ steps.latest.outputs.version }}"
           git push
+          git tag -a "${{ steps.latest.outputs.version }}" -m "Release ${{ steps.latest.outputs.version }}"
+          git push origin "${{ steps.latest.outputs.version }}"


### PR DESCRIPTION
## Summary
- automatically tag new versions when the bouncer is updated

## Testing
- `yamllint .github/workflows/update-bouncer.yml` *(fails: line too long warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6854fa4850c0832dbbeec916d4fe1d5c