### PR TITLE
Add startup version check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,17 @@ RUN if [ "$CS_VERSION" = "latest" ]; then \
     && mv crowdsec-firewall-bouncer*/config/crowdsec-firewall-bouncer.yaml /crowdsec-firewall-bouncer.yaml
 
 FROM alpine:latest
+ARG CS_VERSION
 
 ENV CROWDSEC_PORT="8080" \
     CROWDSEC_LAPI_URL="" \
     PROMETHEUS_ENABLED="false" \
-    PROMETHEUS_PORT="60601"
+    PROMETHEUS_PORT="60601" \
+    BOUNCER_VERSION="$CS_VERSION"
 
 RUN apk update \
     && apk upgrade \
-    && apk add --no-cache nftables nftables iptables ipset gettext ca-certificates tzdata openssl
+    && apk add --no-cache nftables nftables iptables ipset gettext ca-certificates tzdata openssl curl jq
 ENV TZ=UTC
 
 COPY --from=builder /crowdsec-firewall-bouncer /usr/local/bin/crowdsec-firewall-bouncer

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,23 @@ PROMETHEUS_PORT=${PROMETHEUS_PORT:-60601}
 sed -i "0,/enabled:/s/enabled:.*/enabled: ${PROMETHEUS_ENABLED}/" "$CONFIG_FILE"
 sed -i "0,/listen_port:/s/listen_port:.*/listen_port: ${PROMETHEUS_PORT}/" "$CONFIG_FILE"
 
+# Inform about update status on startup
+CURRENT_VERSION="${BOUNCER_VERSION:-unknown}"
+LATEST_VERSION=$(curl -s https://api.github.com/repos/crowdsecurity/cs-firewall-bouncer/releases/latest | jq -r '.tag_name' 2>/dev/null || true)
+if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "null" ]; then
+    if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+        echo "Running the latest image (version $CURRENT_VERSION)."
+    else
+        RELEASES=$(curl -s https://api.github.com/repos/crowdsecurity/cs-firewall-bouncer/releases | jq -r '.[].tag_name' 2>/dev/null || true)
+        BEHIND=0
+        for tag in $RELEASES; do
+            [ "$tag" = "$CURRENT_VERSION" ] && break
+            BEHIND=$((BEHIND+1))
+        done
+        echo "Running version $CURRENT_VERSION - $BEHIND release(s) behind the latest ($LATEST_VERSION)."
+    fi
+else
+    echo "Unable to determine the latest release version."
+fi
+
 exec crowdsec-firewall-bouncer -c "$CONFIG_FILE"


### PR DESCRIPTION
## Summary
- store bouncer version inside the image
- install curl and jq in final stage
- print whether the image is latest at container startup

## Testing
- `sh -n entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68559b350b38832d960d2009eaf5c0a2